### PR TITLE
Setup 'sbt-ci-release' bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: ['2.12.15', '2.13.8']
+        scala: ['2.12.16', '2.13.8']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: temurin
           java-version: 17
           check-latest: true
-      - name: Cache scala dependencies
+      - name: Cache Scala dependencies
         uses: coursier/cache-action@v6
       - name: Check code formatting
         run: sbt check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - uses: olafurpg/setup-scala@v13
+      - run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,22 @@ jobs:
   publish:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2.3.4
+      - name: Checkout current branch
+        uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v13
-      - run: sbt ci-release
+      - name: Setup Java
+        uses: actions/setup-java@v3.1.1
+        with:
+          distribution: temurin
+          java-version: 17
+          check-latest: true
+      - name: Cache scala dependencies
+        uses: coursier/cache-action@v6
+      - name: Release artifacts
+        run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Release
+
 on:
   push:
     branches: [main]
     tags: ["*"]
+
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3.0.2
@@ -17,7 +19,7 @@ jobs:
           distribution: temurin
           java-version: 17
           check-latest: true
-      - name: Cache scala dependencies
+      - name: Cache Scala dependencies
         uses: coursier/cache-action@v6
       - name: Release artifacts
         run: sbt ci-release

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ inThisBuild(
 
 // Sonatype publish options
 sonatypeCredentialHost := "s01.oss.sonatype.org"
-sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
+sonatypeRepository     := "https://s01.oss.sonatype.org/service/local"
 
 addCommandAlias("prepare", "fix; fmt")
 addCommandAlias("check", "fixCheck; fmtCheck")

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaV
 lazy val root = (project in file("."))
   .settings(
     scalaVersion       := "2.13.8",
-    crossScalaVersions := Seq("2.12.15", "2.13.8"),
+    crossScalaVersions := Seq("2.12.16", "2.13.8"),
     libraryDependencies ++= All,
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,

--- a/build.sbt
+++ b/build.sbt
@@ -2,17 +2,35 @@ import Dependencies._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-val basicInfo = List(
-  name        := "scurl-detector",
-  description := "Scala library that detects and extracts URLs from text.",
-  version     := "0.0.1-rc.1"
+inThisBuild(
+  List(
+    name                 := "scurl-detector",
+    description          := "Scala library that detects and extracts URLs from text.",
+    organization         := "io.lambdaworks",
+    organizationName     := "LambdaWorks",
+    organizationHomepage := Some(url("https://www.lambdaworks.io/")),
+    homepage             := Some(url("https://lambdaworks.github.io/scurl-detector/")),
+    licenses             := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
+    developers := List(
+      Developer(
+        "mvelimir",
+        "Velimir Milinković",
+        "velimir@lambdaworks.io",
+        url("https://github.com/mvelimir")
+      ),
+      Developer(
+        "drmarjanovic",
+        "Dragutin Marjanović",
+        "dragutin@lambdaworks.io",
+        url("https://github.com/drmarjanovic")
+      )
+    )
+  )
 )
 
-val organizationInfo = List(
-  organization         := "io.lambdaworks",
-  organizationName     := "LambdaWorks",
-  organizationHomepage := Some(new URL("https://www.lambdaworks.io/"))
-)
+// Sonatype publish options
+sonatypeCredentialHost := "s01.oss.sonatype.org"
+sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 
 addCommandAlias("prepare", "fix; fmt")
 addCommandAlias("check", "fixCheck; fmtCheck")
@@ -25,8 +43,6 @@ ThisBuild / scalafixDependencies ++= ScalaFix
 ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)
 
 lazy val root = (project in file("."))
-  .settings(basicInfo: _*)
-  .settings(organizationInfo: _*)
   .settings(
     scalaVersion       := "2.13.8",
     crossScalaVersions := Seq("2.12.15", "2.13.8"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val UrlDetector           = "0.1.23"
     val ScalaTest             = "3.2.12"
     val CommonsValidator      = "1.7"
-    val ScalaCollectionCompat = "2.8.0"
+    val ScalaCollectionCompat = "2.8.1"
     val ScalaUri              = "4.0.2"
     val OrganizeImports       = "0.5.0"
     val Scaluzzi              = "0.1.20"
@@ -16,16 +16,16 @@ object Dependencies {
 
   import Versions._
 
-  lazy val All =
+  lazy val All: List[ModuleID] =
     List(
       "io.github.url-detector"  % "url-detector"            % UrlDetector,
-      "org.scalatest"          %% "scalatest"               % ScalaTest % Test,
       "commons-validator"       % "commons-validator"       % CommonsValidator,
       "org.scala-lang.modules" %% "scala-collection-compat" % ScalaCollectionCompat,
-      "io.lemonlabs"           %% "scala-uri"               % ScalaUri
+      "io.lemonlabs"           %% "scala-uri"               % ScalaUri,
+      "org.scalatest"          %% "scalatest"               % ScalaTest % Test
     )
 
-  lazy val ScalaFix =
+  lazy val ScalaFix: List[ModuleID] =
     List(
       "com.github.liancheng" %% "organize-imports" % OrganizeImports,
       "com.github.vovapolu"  %% "scaluzzi"         % Scaluzzi

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.4.6")
+addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"   % "0.9.34")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.4.6")
-addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"   % "0.9.34")
+addSbtPlugin("ch.epfl.scala"  % "sbt-scalafix"   % "0.10.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")


### PR DESCRIPTION
### Summary: 

- Provided `sbt-ci-release` [plugin](https://github.com/sbt/sbt-ci-release).
- Provided required GitHub Action secrets.
- Reorganized `build.sbt`. 

### Notes:

- Every push to the `main` branch will create the library snapshot release.
- Every tag push will create the "regular" release. 