### PR TITLE
Add extractAll to support jdbc and credential urls

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ addCommandAlias("fix", "scalafixAll")
 addCommandAlias("fixCheck", "scalafixAll --check")
 
 ThisBuild / scalafixDependencies ++= ScalaFix
-ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)
 
 lazy val root = (project in file("."))
   .settings(


### PR DESCRIPTION
Adds a new **extractAll()** method that detects:
- JDBC connection strings: jdbc:postgres://user:pass@host
- Credential patterns: user:pass@host (normalized to http://user:pass@host)

Backward Compatibility
- Existing extract() method unchanged - returns Set[AbsoluteUrl] for standard web URLs

Implementation
- Returns Set[Url] to support both standard web URLs and opaque URI schemes
- Prevents double-extraction (won't extract both jdbc:mysql://host and http://host)
- Uses negative lookbehind regex to avoid matching emails or HTTP URLs with authentication
