### PR TITLE
Reject URLs with userinfo lacking explicit scheme

### DIFF
--- a/src/test/scala/io/lambdaworks/detection/UrlDetectorSpec.scala
+++ b/src/test/scala/io/lambdaworks/detection/UrlDetectorSpec.scala
@@ -498,4 +498,43 @@ final class UrlDetectorSpec extends AnyFlatSpec with Matchers {
 
   }
 
+  it should "reject URLs with userinfo when no explicit scheme is present" in {
+
+    val testUserinfoWithoutScheme =
+      Table(
+        ("text", "expectedUrls"),
+        (
+          "ono:doope@fb.net:9090/dhdh",
+          Set.empty[Url]
+        ),
+        (
+          "user:pass@host.com",
+          Set.empty[Url]
+        ),
+        (
+          "http://user:pass@host.com",
+          Set(Url.parse("http://user:pass@host.com"))
+        ),
+        (
+          "https://user:pass@host.com",
+          Set(Url.parse("https://user:pass@host.com"))
+        ),
+        (
+          "ftp://user:pass@ftp.example.com",
+          Set(Url.parse("ftp://user:pass@ftp.example.com"))
+        ),
+        (
+          "Check out http://admin:secret@example.com for admin panel",
+          Set(Url.parse("http://admin:secret@example.com"))
+        )
+      )
+
+    val detector = UrlDetector.default
+
+    forAll(testUserinfoWithoutScheme) { (text: String, expectedUrls: Set[Url]) =>
+      detector.extract(text).map(_.toString) shouldBe expectedUrls.map(_.toString)
+    }
+
+  }
+
 }


### PR DESCRIPTION
Previously, inputs like "ono:doope@fb.net:9090/dhdh" were incorrectly detected as valid URLs (http://ono:doope@fb.net:9090/dhdh). This occurs because the LinkedIn URL detector interprets the pattern as userinfo without validating that the original input had an explicit scheme.

This change implements stricter userinfo validation: URLs containing username:password@ are now only accepted if the original input starts with a recognized scheme (http://, https://, ftp://, or ftps://).

 Changes:

  - Track original URL from LinkedIn detector to check for explicit schemes
  - Add validUserinfo() to reject userinfo without explicit scheme prefix
  - Add ValidSchemes constant (http, https, ftp, ftps)
  - Add comprehensive test coverage for userinfo validation

 Fixes URLs like:
  - "ono:doope@fb.net:9090/dhdh" → now rejected (no scheme)
  - "user:pass@host.com" → now rejected (no scheme)

 Still accepts:
  - "http://user:pass@host.com" → valid (explicit http scheme)
  - "https://user:pass@host.com" → valid (explicit https scheme)
